### PR TITLE
Fix _test_rule prompt assignment

### DIFF
--- a/src/promptnado/core.py
+++ b/src/promptnado/core.py
@@ -264,7 +264,8 @@ If you are not sure, try to be conservative and say that the result does not mee
         print(f'\nTesting rule: "{rule.prompt}"')
         self.current_rule = rule
 
-        self.current_prompt = self.current_prompt
+        # Build the prompt for this rule so prediction uses the latest value
+        self.current_prompt = self._build_prompt(rule)
 
         results = evaluate(
             self._predict,


### PR DESCRIPTION
## Summary
- ensure `self.current_prompt` is regenerated when testing rules

## Testing
- `python -m py_compile src/promptnado/core.py`